### PR TITLE
In tooltips, replace <n> with <br> instead of removing them

### DIFF
--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -62,10 +62,13 @@ export function parseTooltipLocaleText(
       continue
     }
 
-    const $ = cheerio.load(localeText[locale])
+    //Fix for Blizzard's sloppy XML errors
+    const localeTextString = localeText[locale].replace(/<\/n>/g, '<n/>');
+
+    const $ = cheerio.load(localeTextString)
 
     $("n").each((index, element) => {
-      $(element).replaceWith(removeNElements($, element))
+      $(element).replaceWith(replaceNWithBrElements($, element))
     })
 
     $("d").each((index, element) => {
@@ -327,12 +330,12 @@ function getValueForReference(ref: TooltipReference, parseData: ParseData): any 
   return getValueAtPath(element, ref.field)
 }
 
-function removeNElements($: CheerioStatic, element: CheerioElement): string {
+function replaceNWithBrElements($: CheerioStatic, element: CheerioElement): string {
   $('n', element).each((index, e) => {
-    $(e).replaceWith(removeNElements($, e))
+    $(e).replaceWith(replaceNWithBrElements($, e))
   })
 
-  return $(element).html()
+  return '<br/>' + $(element).html()
 }
 
 function removeUnmatchedParens(formula: string): string {

--- a/test/tooltip.spec.ts
+++ b/test/tooltip.spec.ts
@@ -46,13 +46,22 @@ describe("parseTooltipLocaleText", function() {
     expect(result.localeText.enus).to.match(/{{ formula1 }}/)
   })
 
-  it("should remove every 'n' element", function() {
+  it("should replace every 'n' element with <br />", function() {
     const localeText = {
       "enus": "Increases <n/><n>stuff <c>things</c><n/>"
     }
 
     const result = parseTooltipLocaleText(localeText, {} as ParseData)
-    expect(result.localeText.enus).to.eql("Increases stuff <span>things</span>")
+    expect(result.localeText.enus).to.eql("Increases <br /><br />stuff <span>things</span><br />")
+  })
+
+  it("should correct malformed 'n' elements", function() {
+    const localeText = {
+      "enus": "Increases </n></n>stuff <c>things</c></n>"
+    }
+
+    const result = parseTooltipLocaleText(localeText, {} as ParseData)
+    expect(result.localeText.enus).to.eql("Increases <br /><br />stuff <span>things</span><br />")
   })
 
   it("should set a formula for every 'd' element in the tooltip text", function() {


### PR DESCRIPTION
Currently, heroes-parser 1.0.11 removes all `<n>` tags (line breaks), and it is impossible to preserve them using standard heroes-parser APIs (short of writing your own `parseTooltipLocaleText()`).

Since line breaks in tooltips are a useful formatting information, `<n>` should be replaced with `<br />` instead of outright removing them. End users who do not need the line breaks can easily adapt to this breaking change by scanning and removing `<br />` tags.

Also, Blizzard seems to erroneously use `</n>` instead of `<n/>` in several places--these do not have a pairing opening tag (`<n>`) and are clearly invalid XML. While it is uncertain how the game engine interprets these invalid tags, I propose that they should be corrected to `<n/>`, since Blizzard developers clearly intended to put line breaks in their place.